### PR TITLE
Add security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 .DS_Store
+
+#Vercel
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self' *.getdbt.com; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; form-action 'self'; frame-ancestors 'none';"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds headers in response to a security report provided from the security team. The report noted schemas.getdbt.com is missing the Content Security Policy header. I also added a few other recommended headers as well.

Full PDF of security report below.
[SecurityScorecard for getdbt.com.pdf](https://github.com/dbt-labs/schemas.getdbt.com/files/15095316/SecurityScorecard.for.getdbt.com.pdf)
