### PR TITLE
Regenerate manifest for dbt-core#9199

### DIFF
--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -639,10 +639,6 @@
                 ],
                 "default": null
               },
-              "deferred": {
-                "type": "boolean",
-                "default": false
-              },
               "unrendered_config": {
                 "type": "object",
                 "propertyNames": {
@@ -728,6 +724,333 @@
                             "type": "null"
                           }
                         ]
+                      },
+                      "resource_type": {
+                        "enum": [
+                          "model",
+                          "analysis",
+                          "test",
+                          "snapshot",
+                          "operation",
+                          "seed",
+                          "rpc",
+                          "sql_operation",
+                          "doc",
+                          "source",
+                          "macro",
+                          "exposure",
+                          "metric",
+                          "group",
+                          "saved_query",
+                          "semantic_model",
+                          "unit_test",
+                          "fixture"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "compiled_code": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "config": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "NodeConfig",
+                            "properties": {
+                              "_extra": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "schema": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "database": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "tags": {
+                                "anyOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "meta": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "group": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "materialized": {
+                                "type": "string",
+                                "default": "view"
+                              },
+                              "incremental_strategy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "persist_docs": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "post-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "pre-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "quoting": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "column_types": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "full_refresh": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "unique_key": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "on_schema_change": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": "ignore"
+                              },
+                              "on_configuration_change": {
+                                "enum": [
+                                  "apply",
+                                  "continue",
+                                  "fail"
+                                ]
+                              },
+                              "grants": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "packages": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "docs": {
+                                "type": "object",
+                                "title": "Docs",
+                                "properties": {
+                                  "show": {
+                                    "type": "boolean",
+                                    "default": true
+                                  },
+                                  "node_color": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "contract": {
+                                "type": "object",
+                                "title": "ContractConfig",
+                                "properties": {
+                                  "enforced": {
+                                    "type": "boolean",
+                                    "default": false
+                                  },
+                                  "alias_types": {
+                                    "type": "boolean",
+                                    "default": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "additionalProperties": false,
@@ -735,7 +1058,14 @@
                       "database",
                       "schema",
                       "alias",
-                      "relation_name"
+                      "relation_name",
+                      "resource_type",
+                      "name",
+                      "description",
+                      "compiled_code",
+                      "meta",
+                      "tags",
+                      "config"
                     ]
                   },
                   {
@@ -1277,10 +1607,6 @@
                   }
                 ],
                 "default": null
-              },
-              "deferred": {
-                "type": "boolean",
-                "default": false
               },
               "unrendered_config": {
                 "type": "object",
@@ -1889,10 +2215,6 @@
                   }
                 ],
                 "default": null
-              },
-              "deferred": {
-                "type": "boolean",
-                "default": false
               },
               "unrendered_config": {
                 "type": "object",
@@ -2626,10 +2948,6 @@
                   }
                 ],
                 "default": null
-              },
-              "deferred": {
-                "type": "boolean",
-                "default": false
               },
               "unrendered_config": {
                 "type": "object",
@@ -3383,10 +3701,6 @@
                 ],
                 "default": null
               },
-              "deferred": {
-                "type": "boolean",
-                "default": false
-              },
               "unrendered_config": {
                 "type": "object",
                 "propertyNames": {
@@ -3723,6 +4037,333 @@
                             "type": "null"
                           }
                         ]
+                      },
+                      "resource_type": {
+                        "enum": [
+                          "model",
+                          "analysis",
+                          "test",
+                          "snapshot",
+                          "operation",
+                          "seed",
+                          "rpc",
+                          "sql_operation",
+                          "doc",
+                          "source",
+                          "macro",
+                          "exposure",
+                          "metric",
+                          "group",
+                          "saved_query",
+                          "semantic_model",
+                          "unit_test",
+                          "fixture"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "compiled_code": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "config": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "NodeConfig",
+                            "properties": {
+                              "_extra": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "schema": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "database": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "tags": {
+                                "anyOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "meta": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "group": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "materialized": {
+                                "type": "string",
+                                "default": "view"
+                              },
+                              "incremental_strategy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "persist_docs": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "post-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "pre-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "quoting": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "column_types": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "full_refresh": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "unique_key": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "on_schema_change": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": "ignore"
+                              },
+                              "on_configuration_change": {
+                                "enum": [
+                                  "apply",
+                                  "continue",
+                                  "fail"
+                                ]
+                              },
+                              "grants": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "packages": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "docs": {
+                                "type": "object",
+                                "title": "Docs",
+                                "properties": {
+                                  "show": {
+                                    "type": "boolean",
+                                    "default": true
+                                  },
+                                  "node_color": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "contract": {
+                                "type": "object",
+                                "title": "ContractConfig",
+                                "properties": {
+                                  "enforced": {
+                                    "type": "boolean",
+                                    "default": false
+                                  },
+                                  "alias_types": {
+                                    "type": "boolean",
+                                    "default": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "additionalProperties": false,
@@ -3730,7 +4371,14 @@
                       "database",
                       "schema",
                       "alias",
-                      "relation_name"
+                      "relation_name",
+                      "resource_type",
+                      "name",
+                      "description",
+                      "compiled_code",
+                      "meta",
+                      "tags",
+                      "config"
                     ]
                   },
                   {
@@ -4272,10 +4920,6 @@
                   }
                 ],
                 "default": null
-              },
-              "deferred": {
-                "type": "boolean",
-                "default": false
               },
               "unrendered_config": {
                 "type": "object",
@@ -4884,10 +5528,6 @@
                   }
                 ],
                 "default": null
-              },
-              "deferred": {
-                "type": "boolean",
-                "default": false
               },
               "unrendered_config": {
                 "type": "object",
@@ -5738,10 +6378,6 @@
                 ],
                 "default": null
               },
-              "deferred": {
-                "type": "boolean",
-                "default": false
-              },
               "unrendered_config": {
                 "type": "object",
                 "propertyNames": {
@@ -5972,6 +6608,333 @@
                             "type": "null"
                           }
                         ]
+                      },
+                      "resource_type": {
+                        "enum": [
+                          "model",
+                          "analysis",
+                          "test",
+                          "snapshot",
+                          "operation",
+                          "seed",
+                          "rpc",
+                          "sql_operation",
+                          "doc",
+                          "source",
+                          "macro",
+                          "exposure",
+                          "metric",
+                          "group",
+                          "saved_query",
+                          "semantic_model",
+                          "unit_test",
+                          "fixture"
+                        ]
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "compiled_code": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "meta": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "config": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "NodeConfig",
+                            "properties": {
+                              "_extra": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "schema": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "database": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "tags": {
+                                "anyOf": [
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "meta": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "group": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "materialized": {
+                                "type": "string",
+                                "default": "view"
+                              },
+                              "incremental_strategy": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "persist_docs": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "post-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "pre-hook": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "title": "Hook",
+                                  "properties": {
+                                    "sql": {
+                                      "type": "string"
+                                    },
+                                    "transaction": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "index": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "required": [
+                                    "sql"
+                                  ]
+                                }
+                              },
+                              "quoting": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "column_types": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "full_refresh": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "unique_key": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "on_schema_change": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": "ignore"
+                              },
+                              "on_configuration_change": {
+                                "enum": [
+                                  "apply",
+                                  "continue",
+                                  "fail"
+                                ]
+                              },
+                              "grants": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "packages": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "docs": {
+                                "type": "object",
+                                "title": "Docs",
+                                "properties": {
+                                  "show": {
+                                    "type": "boolean",
+                                    "default": true
+                                  },
+                                  "node_color": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ],
+                                    "default": null
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "contract": {
+                                "type": "object",
+                                "title": "ContractConfig",
+                                "properties": {
+                                  "enforced": {
+                                    "type": "boolean",
+                                    "default": false
+                                  },
+                                  "alias_types": {
+                                    "type": "boolean",
+                                    "default": true
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "additionalProperties": false,
@@ -5979,7 +6942,14 @@
                       "database",
                       "schema",
                       "alias",
-                      "relation_name"
+                      "relation_name",
+                      "resource_type",
+                      "name",
+                      "description",
+                      "compiled_code",
+                      "meta",
+                      "tags",
+                      "config"
                     ]
                   },
                   {
@@ -8720,10 +9690,6 @@
                       ],
                       "default": null
                     },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
-                    },
                     "unrendered_config": {
                       "type": "object",
                       "propertyNames": {
@@ -8809,6 +9775,333 @@
                                   "type": "null"
                                 }
                               ]
+                            },
+                            "resource_type": {
+                              "enum": [
+                                "model",
+                                "analysis",
+                                "test",
+                                "snapshot",
+                                "operation",
+                                "seed",
+                                "rpc",
+                                "sql_operation",
+                                "doc",
+                                "source",
+                                "macro",
+                                "exposure",
+                                "metric",
+                                "group",
+                                "saved_query",
+                                "semantic_model",
+                                "unit_test",
+                                "fixture"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "compiled_code": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "meta": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "config": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "title": "NodeConfig",
+                                  "properties": {
+                                    "_extra": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "alias": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "database": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "tags": {
+                                      "anyOf": [
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "meta": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "group": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "materialized": {
+                                      "type": "string",
+                                      "default": "view"
+                                    },
+                                    "incremental_strategy": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "persist_docs": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "post-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "pre-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "quoting": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "column_types": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "full_refresh": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "unique_key": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "on_schema_change": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": "ignore"
+                                    },
+                                    "on_configuration_change": {
+                                      "enum": [
+                                        "apply",
+                                        "continue",
+                                        "fail"
+                                      ]
+                                    },
+                                    "grants": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "packages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "docs": {
+                                      "type": "object",
+                                      "title": "Docs",
+                                      "properties": {
+                                        "show": {
+                                          "type": "boolean",
+                                          "default": true
+                                        },
+                                        "node_color": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "contract": {
+                                      "type": "object",
+                                      "title": "ContractConfig",
+                                      "properties": {
+                                        "enforced": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "alias_types": {
+                                          "type": "boolean",
+                                          "default": true
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": true
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
                           "additionalProperties": false,
@@ -8816,7 +10109,14 @@
                             "database",
                             "schema",
                             "alias",
-                            "relation_name"
+                            "relation_name",
+                            "resource_type",
+                            "name",
+                            "description",
+                            "compiled_code",
+                            "meta",
+                            "tags",
+                            "config"
                           ]
                         },
                         {
@@ -9358,10 +10658,6 @@
                         }
                       ],
                       "default": null
-                    },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
                     },
                     "unrendered_config": {
                       "type": "object",
@@ -9970,10 +11266,6 @@
                         }
                       ],
                       "default": null
-                    },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
                     },
                     "unrendered_config": {
                       "type": "object",
@@ -10707,10 +11999,6 @@
                         }
                       ],
                       "default": null
-                    },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
                     },
                     "unrendered_config": {
                       "type": "object",
@@ -11464,10 +12752,6 @@
                       ],
                       "default": null
                     },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
-                    },
                     "unrendered_config": {
                       "type": "object",
                       "propertyNames": {
@@ -11804,6 +13088,333 @@
                                   "type": "null"
                                 }
                               ]
+                            },
+                            "resource_type": {
+                              "enum": [
+                                "model",
+                                "analysis",
+                                "test",
+                                "snapshot",
+                                "operation",
+                                "seed",
+                                "rpc",
+                                "sql_operation",
+                                "doc",
+                                "source",
+                                "macro",
+                                "exposure",
+                                "metric",
+                                "group",
+                                "saved_query",
+                                "semantic_model",
+                                "unit_test",
+                                "fixture"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "compiled_code": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "meta": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "config": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "title": "NodeConfig",
+                                  "properties": {
+                                    "_extra": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "alias": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "database": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "tags": {
+                                      "anyOf": [
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "meta": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "group": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "materialized": {
+                                      "type": "string",
+                                      "default": "view"
+                                    },
+                                    "incremental_strategy": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "persist_docs": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "post-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "pre-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "quoting": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "column_types": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "full_refresh": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "unique_key": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "on_schema_change": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": "ignore"
+                                    },
+                                    "on_configuration_change": {
+                                      "enum": [
+                                        "apply",
+                                        "continue",
+                                        "fail"
+                                      ]
+                                    },
+                                    "grants": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "packages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "docs": {
+                                      "type": "object",
+                                      "title": "Docs",
+                                      "properties": {
+                                        "show": {
+                                          "type": "boolean",
+                                          "default": true
+                                        },
+                                        "node_color": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "contract": {
+                                      "type": "object",
+                                      "title": "ContractConfig",
+                                      "properties": {
+                                        "enforced": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "alias_types": {
+                                          "type": "boolean",
+                                          "default": true
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": true
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
                           "additionalProperties": false,
@@ -11811,7 +13422,14 @@
                             "database",
                             "schema",
                             "alias",
-                            "relation_name"
+                            "relation_name",
+                            "resource_type",
+                            "name",
+                            "description",
+                            "compiled_code",
+                            "meta",
+                            "tags",
+                            "config"
                           ]
                         },
                         {
@@ -12353,10 +13971,6 @@
                         }
                       ],
                       "default": null
-                    },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
                     },
                     "unrendered_config": {
                       "type": "object",
@@ -12965,10 +14579,6 @@
                         }
                       ],
                       "default": null
-                    },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
                     },
                     "unrendered_config": {
                       "type": "object",
@@ -13819,10 +15429,6 @@
                       ],
                       "default": null
                     },
-                    "deferred": {
-                      "type": "boolean",
-                      "default": false
-                    },
                     "unrendered_config": {
                       "type": "object",
                       "propertyNames": {
@@ -14053,6 +15659,333 @@
                                   "type": "null"
                                 }
                               ]
+                            },
+                            "resource_type": {
+                              "enum": [
+                                "model",
+                                "analysis",
+                                "test",
+                                "snapshot",
+                                "operation",
+                                "seed",
+                                "rpc",
+                                "sql_operation",
+                                "doc",
+                                "source",
+                                "macro",
+                                "exposure",
+                                "metric",
+                                "group",
+                                "saved_query",
+                                "semantic_model",
+                                "unit_test",
+                                "fixture"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "compiled_code": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "meta": {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "config": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "title": "NodeConfig",
+                                  "properties": {
+                                    "_extra": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "enabled": {
+                                      "type": "boolean",
+                                      "default": true
+                                    },
+                                    "alias": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "schema": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "database": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "tags": {
+                                      "anyOf": [
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ]
+                                    },
+                                    "meta": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "group": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "materialized": {
+                                      "type": "string",
+                                      "default": "view"
+                                    },
+                                    "incremental_strategy": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "persist_docs": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "post-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "pre-hook": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "title": "Hook",
+                                        "properties": {
+                                          "sql": {
+                                            "type": "string"
+                                          },
+                                          "transaction": {
+                                            "type": "boolean",
+                                            "default": true
+                                          },
+                                          "index": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ],
+                                            "default": null
+                                          }
+                                        },
+                                        "additionalProperties": false,
+                                        "required": [
+                                          "sql"
+                                        ]
+                                      }
+                                    },
+                                    "quoting": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "column_types": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "full_refresh": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "unique_key": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
+                                    },
+                                    "on_schema_change": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": "ignore"
+                                    },
+                                    "on_configuration_change": {
+                                      "enum": [
+                                        "apply",
+                                        "continue",
+                                        "fail"
+                                      ]
+                                    },
+                                    "grants": {
+                                      "type": "object",
+                                      "propertyNames": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "packages": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "docs": {
+                                      "type": "object",
+                                      "title": "Docs",
+                                      "properties": {
+                                        "show": {
+                                          "type": "boolean",
+                                          "default": true
+                                        },
+                                        "node_color": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "contract": {
+                                      "type": "object",
+                                      "title": "ContractConfig",
+                                      "properties": {
+                                        "enforced": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "alias_types": {
+                                          "type": "boolean",
+                                          "default": true
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "additionalProperties": true
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
                           "additionalProperties": false,
@@ -14060,7 +15993,14 @@
                             "database",
                             "schema",
                             "alias",
-                            "relation_name"
+                            "relation_name",
+                            "resource_type",
+                            "name",
+                            "description",
+                            "compiled_code",
+                            "meta",
+                            "tags",
+                            "config"
                           ]
                         },
                         {


### PR DESCRIPTION
This diff correctly reflects two changes in https://github.com/dbt-labs/dbt-core/pull/9199:
- `defer: bool` is being removed from serialized WritableManifest
- `DeferRelation` (which is not included in WritableManifest) includes additional fields, encouraged by [`RelationConfig` protocol](https://github.com/dbt-labs/dbt-adapters/blob/c47c8b5cfc97a351dd5fb804a4c6fb02d8208df0/dbt/adapters/contracts/relation.py#L48), to provide a consistent interface for [`BaseRelation.create_from`](https://github.com/dbt-labs/dbt-adapters/blob/c47c8b5cfc97a351dd5fb804a4c6fb02d8208df0/dbt/adapters/protocol.py#L56)