### PR TITLE
Add `default_granularity` to metric spec

### DIFF
--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -9045,20 +9045,27 @@
             "default": null
           },
           "default_granularity": {
-            "enum": [
-              "nanosecond",
-              "microsecond",
-              "millisecond",
-              "second",
-              "minute",
-              "hour",
-              "day",
-              "week",
-              "month",
-              "quarter",
-              "year"
+            "anyOf": [
+              {
+                "enum": [
+                  "nanosecond",
+                  "microsecond",
+                  "millisecond",
+                  "second",
+                  "minute",
+                  "hour",
+                  "day",
+                  "week",
+                  "month",
+                  "quarter",
+                  "year"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
-            "default": "day"
+            "default": null
           },
           "meta": {
             "type": "object",
@@ -18037,20 +18044,27 @@
                       "default": null
                     },
                     "default_granularity": {
-                      "enum": [
-                        "nanosecond",
-                        "microsecond",
-                        "millisecond",
-                        "second",
-                        "minute",
-                        "hour",
-                        "day",
-                        "week",
-                        "month",
-                        "quarter",
-                        "year"
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "nanosecond",
+                            "microsecond",
+                            "millisecond",
+                            "second",
+                            "minute",
+                            "hour",
+                            "day",
+                            "week",
+                            "month",
+                            "quarter",
+                            "year"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
                       ],
-                      "default": "day"
+                      "default": null
                     },
                     "meta": {
                       "type": "object",

--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -9044,6 +9044,22 @@
             ],
             "default": null
           },
+          "default_granularity": {
+            "enum": [
+              "nanosecond",
+              "microsecond",
+              "millisecond",
+              "second",
+              "minute",
+              "hour",
+              "day",
+              "week",
+              "month",
+              "quarter",
+              "year"
+            ],
+            "default": "day"
+          },
           "meta": {
             "type": "object",
             "propertyNames": {
@@ -18019,6 +18035,22 @@
                         }
                       ],
                       "default": null
+                    },
+                    "default_granularity": {
+                      "enum": [
+                        "nanosecond",
+                        "microsecond",
+                        "millisecond",
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                      ],
+                      "default": "day"
                     },
                     "meta": {
                       "type": "object",


### PR DESCRIPTION
Add `default_granularity` to metric spec

Here's what it looks like in the HTML preview:
<img width="594" alt="Screenshot 2024-07-01 at 12 03 04 PM" src="https://github.com/dbt-labs/schemas.getdbt.com/assets/26731294/5ec04a9d-ad32-479f-b126-90c610498f0b">
