### PR TITLE
Rename `Metric.default_granularity` to `Metric.time_granularity`

### DIFF
--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -9044,7 +9044,7 @@
             ],
             "default": null
           },
-          "default_granularity": {
+          "time_granularity": {
             "anyOf": [
               {
                 "enum": [
@@ -18043,7 +18043,7 @@
                       ],
                       "default": null
                     },
-                    "default_granularity": {
+                    "time_granularity": {
                       "anyOf": [
                         {
                           "enum": [


### PR DESCRIPTION
Related to this PR: https://github.com/dbt-labs/dbt-core/pull/10378

Here is a screenshot of the HTML preview after this change.
<img width="829" alt="Screenshot 2024-07-11 at 11 50 02 AM" src="https://github.com/user-attachments/assets/c8a594c1-611b-4fc4-953c-0ecee071799d">
