### PR TITLE
Updates to support `order_by` and `limit` to saved queries in `v12`

### DIFF
--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -13,7 +13,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.9.0a1"
+          "default": "1.9.0b2"
         },
         "generated_at": {
           "type": "string"
@@ -726,12 +726,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "root_path": {
                 "anyOf": [
@@ -1772,12 +1766,6 @@
                 "type": "string",
                 "default": ""
               },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
-              },
               "language": {
                 "type": "string",
                 "default": "sql"
@@ -2431,12 +2419,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "language": {
                 "type": "string",
@@ -3228,12 +3210,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "language": {
                 "type": "string",
@@ -4044,12 +4020,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "language": {
                 "type": "string",
@@ -5412,12 +5382,6 @@
                 "type": "string",
                 "default": ""
               },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
-              },
               "language": {
                 "type": "string",
                 "default": "sql"
@@ -6071,12 +6035,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "language": {
                 "type": "string",
@@ -6769,6 +6727,17 @@
                       }
                     },
                     "additionalProperties": false
+                  },
+                  "dbt_valid_to_current": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
                   }
                 },
                 "additionalProperties": true
@@ -7035,12 +7004,6 @@
               "raw_code": {
                 "type": "string",
                 "default": ""
-              },
-              "vars": {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
               },
               "language": {
                 "type": "string",
@@ -8179,12 +8142,6 @@
               "type": "string"
             }
           },
-          "vars": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            }
-          },
           "relation_name": {
             "anyOf": [
               {
@@ -8573,12 +8530,6 @@
             "additionalProperties": true
           },
           "unrendered_config": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            }
-          },
-          "vars": {
             "type": "object",
             "propertyNames": {
               "type": "string"
@@ -10661,12 +10612,6 @@
                       "type": "string",
                       "default": ""
                     },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
-                    },
                     "root_path": {
                       "anyOf": [
                         {
@@ -11706,12 +11651,6 @@
                       "type": "string",
                       "default": ""
                     },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
-                    },
                     "language": {
                       "type": "string",
                       "default": "sql"
@@ -12365,12 +12304,6 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
-                    },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
                     },
                     "language": {
                       "type": "string",
@@ -13162,12 +13095,6 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
-                    },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
                     },
                     "language": {
                       "type": "string",
@@ -13978,12 +13905,6 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
-                    },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
                     },
                     "language": {
                       "type": "string",
@@ -15346,12 +15267,6 @@
                       "type": "string",
                       "default": ""
                     },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
-                    },
                     "language": {
                       "type": "string",
                       "default": "sql"
@@ -16005,12 +15920,6 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
-                    },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
                     },
                     "language": {
                       "type": "string",
@@ -16703,6 +16612,17 @@
                             }
                           },
                           "additionalProperties": false
+                        },
+                        "dbt_valid_to_current": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
                         }
                       },
                       "additionalProperties": true
@@ -16969,12 +16889,6 @@
                     "raw_code": {
                       "type": "string",
                       "default": ""
-                    },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
                     },
                     "language": {
                       "type": "string",
@@ -18104,12 +18018,6 @@
                         "type": "string"
                       }
                     },
-                    "vars": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
-                    },
                     "relation_name": {
                       "anyOf": [
                         {
@@ -18296,12 +18204,6 @@
                       "additionalProperties": true
                     },
                     "unrendered_config": {
-                      "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      }
-                    },
-                    "vars": {
                       "type": "object",
                       "propertyNames": {
                         "type": "string"
@@ -19736,6 +19638,23 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "order_by": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "limit": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
                         }
                       },
                       "additionalProperties": false,
@@ -21270,6 +21189,23 @@
                     "type": "null"
                   }
                 ]
+              },
+              "order_by": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "limit": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
Since a schema bump was not necessary, this makes updates to support `order_by` and `limit` in saved queries in the current version. These were generated with:

```
make json_schema version=12
make html version=12
```