### PR TITLE
update v12 manifest schema with dbt-core v1.11 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 1. Are there changes made in the `dbt-core` directory [/core/dbt/artifacts](https://github.com/dbt-labs/dbt-core/tree/main/core/dbt/artifacts) since last release? If not, then you can stop here, no schema changes have been made!
 
-2. From `dbt-core`, run `cd core && hatch run json_schema`
+2. From `dbt-core`, run `cd core && hatch run json-schema`
     * This runs a script that generates the schemas for each artifact in a new `schemas` directory
     * This script creates schema files for all artifacts but you will only need to pay attention to the schema file that you incremented the version for
 

--- a/dbt/catalog/v1.json
+++ b/dbt/catalog/v1.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.10.0a1"
+          "default": "1.11.6"
         },
         "generated_at": {
           "type": "string"

--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -13,7 +13,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.11.0a1"
+          "default": "1.11.6"
         },
         "generated_at": {
           "type": "string"
@@ -8495,6 +8495,51 @@
                   },
                   "concurrent_batches": {
                     "default": null
+                  },
+                  "type": {
+                    "enum": [
+                      "scalar",
+                      "aggregate",
+                      "table"
+                    ],
+                    "default": "scalar"
+                  },
+                  "volatility": {
+                    "anyOf": [
+                      {
+                        "enum": [
+                          "deterministic",
+                          "stable",
+                          "non-deterministic"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "runtime_version": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "entry_point": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
                   }
                 },
                 "additionalProperties": true
@@ -8999,6 +9044,15 @@
                         }
                       ],
                       "default": null
+                    },
+                    "default_value": {
+                      "anyOf": [
+                        {},
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
                     }
                   },
                   "additionalProperties": false,
@@ -9007,14 +9061,6 @@
                     "data_type"
                   ]
                 }
-              },
-              "type": {
-                "enum": [
-                  "scalar",
-                  "aggregate",
-                  "table"
-                ],
-                "default": "scalar"
               }
             },
             "additionalProperties": false,
@@ -20093,6 +20139,51 @@
                         },
                         "concurrent_batches": {
                           "default": null
+                        },
+                        "type": {
+                          "enum": [
+                            "scalar",
+                            "aggregate",
+                            "table"
+                          ],
+                          "default": "scalar"
+                        },
+                        "volatility": {
+                          "anyOf": [
+                            {
+                              "enum": [
+                                "deterministic",
+                                "stable",
+                                "non-deterministic"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "runtime_version": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "entry_point": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
                         }
                       },
                       "additionalProperties": true
@@ -20597,6 +20688,15 @@
                               }
                             ],
                             "default": null
+                          },
+                          "default_value": {
+                            "anyOf": [
+                              {},
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
                           }
                         },
                         "additionalProperties": false,
@@ -20605,14 +20705,6 @@
                           "data_type"
                         ]
                       }
-                    },
-                    "type": {
-                      "enum": [
-                        "scalar",
-                        "aggregate",
-                        "table"
-                      ],
-                      "default": "scalar"
                     }
                   },
                   "additionalProperties": false,
@@ -26611,6 +26703,51 @@
               },
               "concurrent_batches": {
                 "default": null
+              },
+              "type": {
+                "enum": [
+                  "scalar",
+                  "aggregate",
+                  "table"
+                ],
+                "default": "scalar"
+              },
+              "volatility": {
+                "anyOf": [
+                  {
+                    "enum": [
+                      "deterministic",
+                      "stable",
+                      "non-deterministic"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "runtime_version": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "entry_point": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
               }
             },
             "additionalProperties": true
@@ -27115,6 +27252,15 @@
                     }
                   ],
                   "default": null
+                },
+                "default_value": {
+                  "anyOf": [
+                    {},
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
                 }
               },
               "additionalProperties": false,
@@ -27123,14 +27269,6 @@
                 "data_type"
               ]
             }
-          },
-          "type": {
-            "enum": [
-              "scalar",
-              "aggregate",
-              "table"
-            ],
-            "default": "scalar"
           }
         },
         "additionalProperties": false,

--- a/dbt/manifest/v12.json
+++ b/dbt/manifest/v12.json
@@ -13,7 +13,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.10.8"
+          "default": "1.11.0a1"
         },
         "generated_at": {
           "type": "string"
@@ -166,6 +166,18 @@
               "type": "null"
             }
           ]
+        },
+        "run_started_at": {
+          "description": "The timestamp when the run started",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "additionalProperties": false
@@ -911,7 +923,8 @@
                           "saved_query",
                           "semantic_model",
                           "unit_test",
-                          "fixture"
+                          "fixture",
+                          "function"
                         ]
                       },
                       "name": {
@@ -1981,6 +1994,15 @@
                   }
                 }
               },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
               "depends_on": {
                 "type": "object",
                 "title": "DependsOn",
@@ -2664,6 +2686,15 @@
                 }
               },
               "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "functions": {
                 "type": "array",
                 "items": {
                   "type": "array",
@@ -3503,6 +3534,15 @@
                   }
                 }
               },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
               "depends_on": {
                 "type": "object",
                 "title": "DependsOn",
@@ -3998,14 +4038,30 @@
                             "title": "ModelBuildAfter",
                             "properties": {
                               "count": {
-                                "type": "integer"
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
                               },
                               "period": {
-                                "enum": [
-                                  "minute",
-                                  "hour",
-                                  "day"
-                                ]
+                                "anyOf": [
+                                  {
+                                    "enum": [
+                                      "minute",
+                                      "hour",
+                                      "day"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
                               },
                               "updates_on": {
                                 "enum": [
@@ -4015,11 +4071,7 @@
                                 "default": "any"
                               }
                             },
-                            "additionalProperties": true,
-                            "required": [
-                              "count",
-                              "period"
-                            ]
+                            "additionalProperties": true
                           }
                         },
                         "additionalProperties": true,
@@ -4399,6 +4451,15 @@
                   }
                 }
               },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
               "depends_on": {
                 "type": "object",
                 "title": "DependsOn",
@@ -4679,7 +4740,8 @@
                           "saved_query",
                           "semantic_model",
                           "unit_test",
-                          "fixture"
+                          "fixture",
+                          "function"
                         ]
                       },
                       "name": {
@@ -5803,6 +5865,15 @@
                   }
                 }
               },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
               "depends_on": {
                 "type": "object",
                 "title": "DependsOn",
@@ -6486,6 +6557,15 @@
                 }
               },
               "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "functions": {
                 "type": "array",
                 "items": {
                   "type": "array",
@@ -7520,6 +7600,15 @@
                   }
                 }
               },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
               "depends_on": {
                 "type": "object",
                 "title": "DependsOn",
@@ -7677,7 +7766,8 @@
                           "saved_query",
                           "semantic_model",
                           "unit_test",
-                          "fixture"
+                          "fixture",
+                          "function"
                         ]
                       },
                       "name": {
@@ -8025,6 +8115,911 @@
             },
             "additionalProperties": false,
             "required": [
+              "database",
+              "schema",
+              "name",
+              "resource_type",
+              "package_name",
+              "path",
+              "original_file_path",
+              "unique_id",
+              "fqn",
+              "alias",
+              "checksum",
+              "config"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "Function",
+            "properties": {
+              "returns": {
+                "type": "object",
+                "title": "FunctionReturns",
+                "properties": {
+                  "data_type": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "data_type"
+                ]
+              },
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "schema": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "resource_type": {
+                "const": "function"
+              },
+              "package_name": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              },
+              "original_file_path": {
+                "type": "string"
+              },
+              "unique_id": {
+                "type": "string"
+              },
+              "fqn": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alias": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "object",
+                "title": "FileHash",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "checksum": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "name",
+                  "checksum"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "title": "FunctionConfig",
+                "properties": {
+                  "_extra": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "alias": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "schema": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "database": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "materialized": {
+                    "type": "string",
+                    "default": "function"
+                  },
+                  "incremental_strategy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "batch_size": {
+                    "default": null
+                  },
+                  "lookback": {
+                    "default": 1
+                  },
+                  "begin": {
+                    "default": null
+                  },
+                  "persist_docs": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "post-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "pre-hook": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "title": "Hook",
+                      "properties": {
+                        "sql": {
+                          "type": "string"
+                        },
+                        "transaction": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "index": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "sql"
+                      ]
+                    }
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "column_types": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "full_refresh": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "unique_key": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  },
+                  "on_schema_change": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": "ignore"
+                  },
+                  "on_configuration_change": {
+                    "enum": [
+                      "apply",
+                      "continue",
+                      "fail"
+                    ]
+                  },
+                  "grants": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    }
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "docs": {
+                    "type": "object",
+                    "title": "Docs",
+                    "properties": {
+                      "show": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "node_color": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "contract": {
+                    "type": "object",
+                    "title": "ContractConfig",
+                    "properties": {
+                      "enforced": {
+                        "type": "boolean",
+                        "default": false
+                      },
+                      "alias_types": {
+                        "type": "boolean",
+                        "default": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "event_time": {
+                    "default": null
+                  },
+                  "concurrent_batches": {
+                    "default": null
+                  }
+                },
+                "additionalProperties": true
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string",
+                "default": ""
+              },
+              "columns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "title": "ColumnInfo",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "data_type": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "ColumnLevelConstraint",
+                        "properties": {
+                          "type": {
+                            "enum": [
+                              "check",
+                              "not_null",
+                              "unique",
+                              "primary_key",
+                              "foreign_key",
+                              "custom"
+                            ]
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "expression": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "warn_unenforced": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "warn_unsupported": {
+                            "type": "boolean",
+                            "default": true
+                          },
+                          "to": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "to_columns": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    },
+                    "quote": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "ColumnConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "granularity": {
+                      "anyOf": [
+                        {
+                          "enum": [
+                            "nanosecond",
+                            "microsecond",
+                            "millisecond",
+                            "second",
+                            "minute",
+                            "hour",
+                            "day",
+                            "week",
+                            "month",
+                            "quarter",
+                            "year"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "name"
+                  ]
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "patch_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "build_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "unrendered_config": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "created_at": {
+                "type": "number"
+              },
+              "config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "unrendered_config_call_dict": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "relation_name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "raw_code": {
+                "type": "string",
+                "default": ""
+              },
+              "doc_blocks": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "language": {
+                "type": "string",
+                "default": "sql"
+              },
+              "refs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "RefArgs",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "package": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "version": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name"
+                  ]
+                }
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "depends_on": {
+                "type": "object",
+                "title": "DependsOn",
+                "properties": {
+                  "macros": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "nodes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "compiled_path": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "compiled": {
+                "type": "boolean",
+                "default": false
+              },
+              "compiled_code": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "extra_ctes_injected": {
+                "type": "boolean",
+                "default": false
+              },
+              "extra_ctes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "InjectedCTE",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "sql": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "id",
+                    "sql"
+                  ]
+                }
+              },
+              "_pre_injected_sql": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "contract": {
+                "type": "object",
+                "title": "Contract",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "checksum": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "arguments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "FunctionArgument",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "data_type": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "name",
+                    "data_type"
+                  ]
+                }
+              },
+              "type": {
+                "enum": [
+                  "scalar",
+                  "aggregate",
+                  "table"
+                ],
+                "default": "scalar"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "returns",
               "database",
               "schema",
               "name",
@@ -10158,9 +11153,244 @@
                           "average"
                         ],
                         "default": "first"
+                      },
+                      "metric": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "MetricInput",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "title": "WhereFilterIntersection",
+                                    "properties": {
+                                      "where_filters": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "title": "WhereFilter",
+                                          "properties": {
+                                            "where_sql_template": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "additionalProperties": false,
+                                          "required": [
+                                            "where_sql_template"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "where_filters"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "alias": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "offset_window": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "title": "MetricTimeWindow",
+                                    "properties": {
+                                      "count": {
+                                        "type": "integer"
+                                      },
+                                      "granularity": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                      "count",
+                                      "granularity"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "offset_to_grain": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
                       }
                     },
                     "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "metric_aggregation_params": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "title": "MetricAggregationParams",
+                    "properties": {
+                      "semantic_model": {
+                        "type": "string"
+                      },
+                      "agg": {
+                        "enum": [
+                          "sum",
+                          "min",
+                          "max",
+                          "count_distinct",
+                          "sum_boolean",
+                          "average",
+                          "percentile",
+                          "median",
+                          "count"
+                        ]
+                      },
+                      "agg_params": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "MeasureAggregationParameters",
+                            "properties": {
+                              "percentile": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              "use_discrete_percentile": {
+                                "type": "boolean",
+                                "default": false
+                              },
+                              "use_approximate_percentile": {
+                                "type": "boolean",
+                                "default": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "agg_time_dimension": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "non_additive_dimension": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "title": "NonAdditiveDimension",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "window_choice": {
+                                "enum": [
+                                  "sum",
+                                  "min",
+                                  "max",
+                                  "count_distinct",
+                                  "sum_boolean",
+                                  "average",
+                                  "percentile",
+                                  "median",
+                                  "count"
+                                ]
+                              },
+                              "window_groupings": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "name",
+                              "window_choice",
+                              "window_groupings"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "expr": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "semantic_model",
+                      "agg"
+                    ]
                   },
                   {
                     "type": "null"
@@ -11291,7 +12521,8 @@
                                 "saved_query",
                                 "semantic_model",
                                 "unit_test",
-                                "fixture"
+                                "fixture",
+                                "function"
                               ]
                             },
                             "name": {
@@ -12361,6 +13592,15 @@
                         }
                       }
                     },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "depends_on": {
                       "type": "object",
                       "title": "DependsOn",
@@ -13044,6 +14284,15 @@
                       }
                     },
                     "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "functions": {
                       "type": "array",
                       "items": {
                         "type": "array",
@@ -13883,6 +15132,15 @@
                         }
                       }
                     },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "depends_on": {
                       "type": "object",
                       "title": "DependsOn",
@@ -14378,14 +15636,30 @@
                                   "title": "ModelBuildAfter",
                                   "properties": {
                                     "count": {
-                                      "type": "integer"
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
                                     },
                                     "period": {
-                                      "enum": [
-                                        "minute",
-                                        "hour",
-                                        "day"
-                                      ]
+                                      "anyOf": [
+                                        {
+                                          "enum": [
+                                            "minute",
+                                            "hour",
+                                            "day"
+                                          ]
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "default": null
                                     },
                                     "updates_on": {
                                       "enum": [
@@ -14395,11 +15669,7 @@
                                       "default": "any"
                                     }
                                   },
-                                  "additionalProperties": true,
-                                  "required": [
-                                    "count",
-                                    "period"
-                                  ]
+                                  "additionalProperties": true
                                 }
                               },
                               "additionalProperties": true,
@@ -14779,6 +16049,15 @@
                         }
                       }
                     },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "depends_on": {
                       "type": "object",
                       "title": "DependsOn",
@@ -15059,7 +16338,8 @@
                                 "saved_query",
                                 "semantic_model",
                                 "unit_test",
-                                "fixture"
+                                "fixture",
+                                "function"
                               ]
                             },
                             "name": {
@@ -16183,6 +17463,15 @@
                         }
                       }
                     },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "depends_on": {
                       "type": "object",
                       "title": "DependsOn",
@@ -16866,6 +18155,15 @@
                       }
                     },
                     "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "functions": {
                       "type": "array",
                       "items": {
                         "type": "array",
@@ -17900,6 +19198,15 @@
                         }
                       }
                     },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "depends_on": {
                       "type": "object",
                       "title": "DependsOn",
@@ -18057,7 +19364,8 @@
                                 "saved_query",
                                 "semantic_model",
                                 "unit_test",
-                                "fixture"
+                                "fixture",
+                                "function"
                               ]
                             },
                             "name": {
@@ -18405,6 +19713,911 @@
                   },
                   "additionalProperties": false,
                   "required": [
+                    "database",
+                    "schema",
+                    "name",
+                    "resource_type",
+                    "package_name",
+                    "path",
+                    "original_file_path",
+                    "unique_id",
+                    "fqn",
+                    "alias",
+                    "checksum",
+                    "config"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "title": "Function",
+                  "properties": {
+                    "returns": {
+                      "type": "object",
+                      "title": "FunctionReturns",
+                      "properties": {
+                        "data_type": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "data_type"
+                      ]
+                    },
+                    "database": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "schema": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "resource_type": {
+                      "const": "function"
+                    },
+                    "package_name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "original_file_path": {
+                      "type": "string"
+                    },
+                    "unique_id": {
+                      "type": "string"
+                    },
+                    "fqn": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "alias": {
+                      "type": "string"
+                    },
+                    "checksum": {
+                      "type": "object",
+                      "title": "FileHash",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "checksum": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "name",
+                        "checksum"
+                      ]
+                    },
+                    "config": {
+                      "type": "object",
+                      "title": "FunctionConfig",
+                      "properties": {
+                        "_extra": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "enabled": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "alias": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "schema": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "database": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "tags": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "meta": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "materialized": {
+                          "type": "string",
+                          "default": "function"
+                        },
+                        "incremental_strategy": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "batch_size": {
+                          "default": null
+                        },
+                        "lookback": {
+                          "default": 1
+                        },
+                        "begin": {
+                          "default": null
+                        },
+                        "persist_docs": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "post-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "pre-hook": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "title": "Hook",
+                            "properties": {
+                              "sql": {
+                                "type": "string"
+                              },
+                              "transaction": {
+                                "type": "boolean",
+                                "default": true
+                              },
+                              "index": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "default": null
+                              }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                              "sql"
+                            ]
+                          }
+                        },
+                        "quoting": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "column_types": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "full_refresh": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "unique_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "on_schema_change": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": "ignore"
+                        },
+                        "on_configuration_change": {
+                          "enum": [
+                            "apply",
+                            "continue",
+                            "fail"
+                          ]
+                        },
+                        "grants": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          }
+                        },
+                        "packages": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "docs": {
+                          "type": "object",
+                          "title": "Docs",
+                          "properties": {
+                            "show": {
+                              "type": "boolean",
+                              "default": true
+                            },
+                            "node_color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "default": null
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "contract": {
+                          "type": "object",
+                          "title": "ContractConfig",
+                          "properties": {
+                            "enforced": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "alias_types": {
+                              "type": "boolean",
+                              "default": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "event_time": {
+                          "default": null
+                        },
+                        "concurrent_batches": {
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "columns": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "title": "ColumnInfo",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string",
+                            "default": ""
+                          },
+                          "meta": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "data_type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "constraints": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "title": "ColumnLevelConstraint",
+                              "properties": {
+                                "type": {
+                                  "enum": [
+                                    "check",
+                                    "not_null",
+                                    "unique",
+                                    "primary_key",
+                                    "foreign_key",
+                                    "custom"
+                                  ]
+                                },
+                                "name": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expression": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "warn_unenforced": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "warn_unsupported": {
+                                  "type": "boolean",
+                                  "default": true
+                                },
+                                "to": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "to_columns": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "type"
+                              ]
+                            }
+                          },
+                          "quote": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "config": {
+                            "type": "object",
+                            "title": "ColumnConfig",
+                            "properties": {
+                              "_extra": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "meta": {
+                                "type": "object",
+                                "propertyNames": {
+                                  "type": "string"
+                                }
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": true
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "_extra": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            }
+                          },
+                          "granularity": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "nanosecond",
+                                  "microsecond",
+                                  "millisecond",
+                                  "second",
+                                  "minute",
+                                  "hour",
+                                  "day",
+                                  "week",
+                                  "month",
+                                  "quarter",
+                                  "year"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "doc_blocks": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "additionalProperties": true,
+                        "required": [
+                          "name"
+                        ]
+                      },
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "group": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "docs": {
+                      "type": "object",
+                      "title": "Docs",
+                      "properties": {
+                        "show": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "node_color": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "patch_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "build_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "unrendered_config": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "created_at": {
+                      "type": "number"
+                    },
+                    "config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "unrendered_config_call_dict": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "relation_name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "raw_code": {
+                      "type": "string",
+                      "default": ""
+                    },
+                    "doc_blocks": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "language": {
+                      "type": "string",
+                      "default": "sql"
+                    },
+                    "refs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "RefArgs",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          },
+                          "version": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    },
+                    "sources": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "metrics": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "depends_on": {
+                      "type": "object",
+                      "title": "DependsOn",
+                      "properties": {
+                        "macros": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "nodes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "compiled_path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "compiled": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "compiled_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "extra_ctes_injected": {
+                      "type": "boolean",
+                      "default": false
+                    },
+                    "extra_ctes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "InjectedCTE",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sql": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "id",
+                          "sql"
+                        ]
+                      }
+                    },
+                    "_pre_injected_sql": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    },
+                    "contract": {
+                      "type": "object",
+                      "title": "Contract",
+                      "properties": {
+                        "enforced": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "alias_types": {
+                          "type": "boolean",
+                          "default": true
+                        },
+                        "checksum": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "arguments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "title": "FunctionArgument",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "data_type": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "default": null
+                          }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                          "name",
+                          "data_type"
+                        ]
+                      }
+                    },
+                    "type": {
+                      "enum": [
+                        "scalar",
+                        "aggregate",
+                        "table"
+                      ],
+                      "default": "scalar"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "returns",
                     "database",
                     "schema",
                     "name",
@@ -20320,9 +22533,244 @@
                                     "average"
                                   ],
                                   "default": "first"
+                                },
+                                "metric": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "MetricInput",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "filter": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "title": "WhereFilterIntersection",
+                                              "properties": {
+                                                "where_filters": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "title": "WhereFilter",
+                                                    "properties": {
+                                                      "where_sql_template": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                      "where_sql_template"
+                                                    ]
+                                                  }
+                                                }
+                                              },
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "where_filters"
+                                              ]
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "alias": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "offset_window": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "title": "MetricTimeWindow",
+                                              "properties": {
+                                                "count": {
+                                                  "type": "integer"
+                                                },
+                                                "granularity": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "additionalProperties": false,
+                                              "required": [
+                                                "count",
+                                                "granularity"
+                                              ]
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "offset_to_grain": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "name"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
                                 }
                               },
                               "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "default": null
+                        },
+                        "metric_aggregation_params": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "title": "MetricAggregationParams",
+                              "properties": {
+                                "semantic_model": {
+                                  "type": "string"
+                                },
+                                "agg": {
+                                  "enum": [
+                                    "sum",
+                                    "min",
+                                    "max",
+                                    "count_distinct",
+                                    "sum_boolean",
+                                    "average",
+                                    "percentile",
+                                    "median",
+                                    "count"
+                                  ]
+                                },
+                                "agg_params": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "MeasureAggregationParameters",
+                                      "properties": {
+                                        "percentile": {
+                                          "anyOf": [
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ],
+                                          "default": null
+                                        },
+                                        "use_discrete_percentile": {
+                                          "type": "boolean",
+                                          "default": false
+                                        },
+                                        "use_approximate_percentile": {
+                                          "type": "boolean",
+                                          "default": false
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "agg_time_dimension": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "non_additive_dimension": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "title": "NonAdditiveDimension",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "window_choice": {
+                                          "enum": [
+                                            "sum",
+                                            "min",
+                                            "max",
+                                            "count_distinct",
+                                            "sum_boolean",
+                                            "average",
+                                            "percentile",
+                                            "median",
+                                            "count"
+                                          ]
+                                        },
+                                        "window_groupings": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "name",
+                                        "window_choice",
+                                        "window_groupings"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                },
+                                "expr": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": null
+                                }
+                              },
+                              "additionalProperties": false,
+                              "required": [
+                                "semantic_model",
+                                "agg"
+                              ]
                             },
                             {
                               "type": "null"
@@ -21034,7 +23482,8 @@
                         "saved_query",
                         "semantic_model",
                         "unit_test",
-                        "fixture"
+                        "fixture",
+                        "function"
                       ]
                     },
                     "package_name": {
@@ -21917,7 +24366,8 @@
                         "saved_query",
                         "semantic_model",
                         "unit_test",
-                        "fixture"
+                        "fixture",
+                        "function"
                       ]
                     },
                     "package_name": {
@@ -22672,7 +25122,8 @@
               "saved_query",
               "semantic_model",
               "unit_test",
-              "fixture"
+              "fixture",
+              "function"
             ]
           },
           "package_name": {
@@ -23562,7 +26013,8 @@
               "saved_query",
               "semantic_model",
               "unit_test",
-              "fixture"
+              "fixture",
+              "function"
             ]
           },
           "package_name": {
@@ -23784,6 +26236,918 @@
           "original_file_path",
           "unique_id",
           "fqn"
+        ]
+      },
+      "propertyNames": {
+        "type": "string"
+      }
+    },
+    "functions": {
+      "type": "object",
+      "description": "The functions defined in the dbt project",
+      "additionalProperties": {
+        "type": "object",
+        "title": "Function",
+        "properties": {
+          "returns": {
+            "type": "object",
+            "title": "FunctionReturns",
+            "properties": {
+              "data_type": {
+                "type": "string"
+              },
+              "description": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "data_type"
+            ]
+          },
+          "database": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "resource_type": {
+            "const": "function"
+          },
+          "package_name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "original_file_path": {
+            "type": "string"
+          },
+          "unique_id": {
+            "type": "string"
+          },
+          "fqn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "alias": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "object",
+            "title": "FileHash",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "checksum"
+            ]
+          },
+          "config": {
+            "type": "object",
+            "title": "FunctionConfig",
+            "properties": {
+              "_extra": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "enabled": {
+                "type": "boolean",
+                "default": true
+              },
+              "alias": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "database": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "tags": {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "materialized": {
+                "type": "string",
+                "default": "function"
+              },
+              "incremental_strategy": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "batch_size": {
+                "default": null
+              },
+              "lookback": {
+                "default": 1
+              },
+              "begin": {
+                "default": null
+              },
+              "persist_docs": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "post-hook": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "Hook",
+                  "properties": {
+                    "sql": {
+                      "type": "string"
+                    },
+                    "transaction": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "index": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "sql"
+                  ]
+                }
+              },
+              "pre-hook": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "Hook",
+                  "properties": {
+                    "sql": {
+                      "type": "string"
+                    },
+                    "transaction": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "index": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "sql"
+                  ]
+                }
+              },
+              "quoting": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "column_types": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "full_refresh": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "unique_key": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              },
+              "on_schema_change": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": "ignore"
+              },
+              "on_configuration_change": {
+                "enum": [
+                  "apply",
+                  "continue",
+                  "fail"
+                ]
+              },
+              "grants": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "docs": {
+                "type": "object",
+                "title": "Docs",
+                "properties": {
+                  "show": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "node_color": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "default": null
+                  }
+                },
+                "additionalProperties": false
+              },
+              "contract": {
+                "type": "object",
+                "title": "ContractConfig",
+                "properties": {
+                  "enforced": {
+                    "type": "boolean",
+                    "default": false
+                  },
+                  "alias_types": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                },
+                "additionalProperties": false
+              },
+              "event_time": {
+                "default": null
+              },
+              "concurrent_batches": {
+                "default": null
+              }
+            },
+            "additionalProperties": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string",
+            "default": ""
+          },
+          "columns": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "title": "ColumnInfo",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string",
+                  "default": ""
+                },
+                "meta": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  }
+                },
+                "data_type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "constraints": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "title": "ColumnLevelConstraint",
+                    "properties": {
+                      "type": {
+                        "enum": [
+                          "check",
+                          "not_null",
+                          "unique",
+                          "primary_key",
+                          "foreign_key",
+                          "custom"
+                        ]
+                      },
+                      "name": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "expression": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "warn_unenforced": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "warn_unsupported": {
+                        "type": "boolean",
+                        "default": true
+                      },
+                      "to": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "default": null
+                      },
+                      "to_columns": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "quote": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "config": {
+                  "type": "object",
+                  "title": "ColumnConfig",
+                  "properties": {
+                    "_extra": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": true
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "_extra": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  }
+                },
+                "granularity": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "nanosecond",
+                        "microsecond",
+                        "millisecond",
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "doc_blocks": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": true,
+              "required": [
+                "name"
+              ]
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "meta": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "docs": {
+            "type": "object",
+            "title": "Docs",
+            "properties": {
+              "show": {
+                "type": "boolean",
+                "default": true
+              },
+              "node_color": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "patch_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "build_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "unrendered_config": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "config_call_dict": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "unrendered_config_call_dict": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "relation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "raw_code": {
+            "type": "string",
+            "default": ""
+          },
+          "doc_blocks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "language": {
+            "type": "string",
+            "default": "sql"
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "RefArgs",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "package": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "version": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ]
+            }
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "functions": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "depends_on": {
+            "type": "object",
+            "title": "DependsOn",
+            "properties": {
+              "macros": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "compiled_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "compiled": {
+            "type": "boolean",
+            "default": false
+          },
+          "compiled_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "extra_ctes_injected": {
+            "type": "boolean",
+            "default": false
+          },
+          "extra_ctes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "InjectedCTE",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sql": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "id",
+                "sql"
+              ]
+            }
+          },
+          "_pre_injected_sql": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "contract": {
+            "type": "object",
+            "title": "Contract",
+            "properties": {
+              "enforced": {
+                "type": "boolean",
+                "default": false
+              },
+              "alias_types": {
+                "type": "boolean",
+                "default": true
+              },
+              "checksum": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null
+              }
+            },
+            "additionalProperties": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "FunctionArgument",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "data_type": {
+                  "type": "string"
+                },
+                "description": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "data_type"
+              ]
+            }
+          },
+          "type": {
+            "enum": [
+              "scalar",
+              "aggregate",
+              "table"
+            ],
+            "default": "scalar"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "returns",
+          "database",
+          "schema",
+          "name",
+          "resource_type",
+          "package_name",
+          "path",
+          "original_file_path",
+          "unique_id",
+          "fqn",
+          "alias",
+          "checksum",
+          "config"
         ]
       },
       "propertyNames": {

--- a/dbt/run-results/v6.json
+++ b/dbt/run-results/v6.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.10.0a1"
+          "default": "1.11.6"
         },
         "generated_at": {
           "type": "string"

--- a/dbt/sources/v3.json
+++ b/dbt/sources/v3.json
@@ -12,7 +12,7 @@
         },
         "dbt_version": {
           "type": "string",
-          "default": "1.10.0a1"
+          "default": "1.11.6"
         },
         "generated_at": {
           "type": "string"


### PR DESCRIPTION

 Update v12 manifest schema with dbt-core v1.11 changes, from dbt-core @ 1.11.latest
                                                                                                                                                                             
 ### Summary         

  - Updates the v12 manifest JSON schema and corresponding HTML documentation to reflect changes from dbt-core v1.11 (bumps version from 1.10.8 to 1.11.6)

 ### Key schema changes

  New function resource type:
  - Added "function" to the ResourceType enum across all node types
  - Added functions property (array of string arrays) to multiple node definitions (models, seeds, analyses, snapshots, tests, etc.)

 ### New manifest metadata field:
  - Added run_started_at (nullable string) to the manifest metadata

 ### Microbatch / ModelBuildAfter changes:
  - count and period fields on ModelBuildAfter are now nullable (with default: null) instead of required
  - Added concurrent_batches and batch_size properties to relevant node configs